### PR TITLE
Override JBake properties from plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
             <dependency>
                 <groupId>org.jbake</groupId>
                 <artifactId>jbake-core</artifactId>
-                <version>2.3.2</version>
+                <version>2.4.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
This change allows to override JBake properties or define custom
properties which can be used in the templates, e.g.:
```
<plugin>
    <groupId>br.com.ingenieux</groupId>
    <artifactId>jbake-maven-plugin</artifactId>
    <executions>
        ...
    </executions>
    <configuration>
        <properties>
            <!-- override JBake property -->
            <render.feed>true</render.feed>
            <!-- define custom property -->
            <foo>bar</foo>
        </properties>
    </configuration>
</plugin>
```
To make this possible an update to JBake 2.4.0 was necessary.

This fixes #3 and resolves #11.